### PR TITLE
feat: Setup HTTP server scaffold

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module memory_match
+
+go 1.17

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -1,0 +1,29 @@
+// Package http implements a standard HTTP server.
+package http
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type server struct {
+	publicServer *http.Server
+}
+
+func ping() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("pong"))
+	}
+}
+
+func NewHttpServer(port int) *server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", ping())
+
+	return &server{
+		publicServer: &http.Server{
+			Addr:    fmt.Sprintf(":%d", port),
+			Handler: mux,
+		},
+	}
+}


### PR DESCRIPTION
Adds an `http` package which creates an `HttpServer` with a default `ping` endpoint.

Following https://github.com/golang-standards/project-layout for Golang project layout ideas. This is probably much more than what I would need for this project, but using it as a learning experience.