### PR TITLE
feat: Port integration test to Go cmd

### DIFF
--- a/.github/workflows/server-integration-test.yml
+++ b/.github/workflows/server-integration-test.yml
@@ -1,0 +1,13 @@
+name: server-integration-test
+on: [pull_request]
+jobs:
+  get-ping-endpoint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.17.8'
+      - run: go run cmd/test/main.go
+
+

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "card-match/internal/cmd/test"
+
+func main() {
+	cmd := test.Cmd()
+	cmd.Execute()
+}

--- a/internal/cmd/api/server.go
+++ b/internal/cmd/api/server.go
@@ -22,6 +22,14 @@ func NewServer(config *Config) *server {
 
 }
 
+func NewDefaultServer() *server {
+	applicationServer := NewApplicationServer(8080)
+
+	return &server{
+		applicationServer: applicationServer,
+	}
+}
+
 func (s *server) StartApplicationServer() error {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/cmd/test/root.go
+++ b/internal/cmd/test/root.go
@@ -16,18 +16,22 @@ func Cmd() *cobra.Command {
 			server := api.NewDefaultServer()
 			go server.StartApplicationServer()
 
-			resp, err := http.Get("http://localhost:8080/ping")
+			// Add retry policy in case the server is slow to start up.
+			for i := 0; i <= 50; i++ {
+				resp, err := http.Get("http://localhost:8080/ping")
 
-			if err != nil {
-				panic(err)
+				if err != nil || resp.StatusCode != 200 {
+					continue
+				}
+
+				if resp.StatusCode == 200 {
+					fmt.Print("Received a succesful response")
+					return
+				}
+
 			}
 
-			if resp.StatusCode != 200 {
-				panic("Did not receive a successful response")
-			}
-
-			fmt.Print("Received a successful response")
-
+			panic("Did not receive a successful response")
 		}}
 
 	return cmd

--- a/internal/cmd/test/root.go
+++ b/internal/cmd/test/root.go
@@ -1,0 +1,34 @@
+package test
+
+import (
+	"card-match/internal/cmd/api"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Run integration tests",
+		Run: func(cmd *cobra.Command, _ []string) {
+			server := api.NewDefaultServer()
+			go server.StartApplicationServer()
+
+			resp, err := http.Get("http://localhost:8080/ping")
+
+			if err != nil {
+				panic(err)
+			}
+
+			if resp.StatusCode != 200 {
+				panic("Did not receive a successful response")
+			}
+
+			fmt.Print("Received a successful response")
+
+		}}
+
+	return cmd
+}


### PR DESCRIPTION
This commit ports the previous integration test written as a shell
script, to be a cmd entry point that can be compiled, installed, and
run.

The next commit will focus on running this test continuously upon PR creation.