### PR TITLE
feat: Add `getRandomBoard` endpoint

### DIFF
--- a/internal/cmd/api/application_server.go
+++ b/internal/cmd/api/application_server.go
@@ -3,18 +3,30 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 func ping() http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte("pong"))
 	}
+}
+
+func getRandomBoard() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		// TODO: Actually make this random.
+		randomizedBoard := 12231434
+		w.Write([]byte(strconv.Itoa(randomizedBoard)))
+
+	}
+
 }
 
 // An HTTP server with a single /ping endpoint.
 func NewApplicationServer(port int) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ping", ping())
+	mux.HandleFunc("/getRandomBoard", getRandomBoard())
 
 	applicationServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),


### PR DESCRIPTION
This commit adds a `getRandomBoard` endpoint scaffold. The board is not
actually random (yet), but wanted to get the HTTP handler in place.

A couple of questions:

1. Right now, I'm returning an integer where each digit of the integer
   represents the ordering of the value. For example, 1212 means that
   the 1's will be 2 spots away from each other (1 -> 2 -> 1). I wonder
   if there is a better way to encode this information.

2. I'm using `content-type: plain/text` but it might make sense to use
   `application/json` in the future. Or even to use protobuf as a
   message format.
